### PR TITLE
RTCOM_EL_OP_STR_LIKE

### DIFF
--- a/rtcom-eventlogger/eventlogger-types.h
+++ b/rtcom-eventlogger/eventlogger-types.h
@@ -76,9 +76,11 @@ typedef enum {
     RTCOM_EL_OP_LESS,          /** Test if the first operand is smaller. */
     RTCOM_EL_OP_LESS_EQUAL,    /** Test if the first operand is smaller or equal. */
     RTCOM_EL_OP_IN_STRV,       /** Tests if the first operand is one of the strings in the array */
-    RTCOM_EL_OP_STR_ENDS_WITH  /** Tests if the first operand (a string) ends
-                                   with the given string. NOTE: not supported
-                                   when querying for "service", "event-type".*/
+    RTCOM_EL_OP_STR_ENDS_WITH, /** Tests if the first operand (a string) ends with the given string.
+                                   NOTE: not supported when querying for "service", "event-type". */
+    RTCOM_EL_OP_STR_LIKE       /** Tests if the first operand (a string) is present
+                                   NOTE: not supported when querying for "service", "event-type". Case-insensitive. */
+
 } RTComElOp;
 
 #define RTCOM_EL_FLAG_GENERIC_READ 1<<0

--- a/src/eventlogger-query.c
+++ b/src/eventlogger-query.c
@@ -468,7 +468,17 @@ _build_where_clause(
             }
 
         case G_TYPE_STRING:
-            if(op == RTCOM_EL_OP_IN_STRV)
+            {
+            if(op == RTCOM_EL_OP_STR_LIKE)
+            {
+                gchar *string_val = (gchar *) val;
+                char *tmp = sqlite3_mprintf("%s LIKE '%q'",
+                                            (gchar *) g_hash_table_lookup(priv->mapping, key),
+                                            string_val);
+                g_string_append(ret, tmp);
+                sqlite3_free(tmp);
+            }
+            else if(op == RTCOM_EL_OP_IN_STRV)
             {
                 gchar **strv_val = (gchar **) val;
                 g_string_append_printf(
@@ -506,7 +516,7 @@ _build_where_clause(
                 sqlite3_free (tmp);
             }
             return TRUE;
-
+            }
         default:
             g_debug ("%s: unknown key %s", G_STRFUNC, key);
             g_return_val_if_reached (FALSE);
@@ -526,6 +536,7 @@ _build_operator (RTComElOp op)
         case RTCOM_EL_OP_LESS_EQUAL: return "<=";
         case RTCOM_EL_OP_IN_STRV: g_return_val_if_reached(NULL);
         case RTCOM_EL_OP_STR_ENDS_WITH: g_return_val_if_reached(NULL);
+        case RTCOM_EL_OP_STR_LIKE: g_return_val_if_reached(NULL);
         default: g_return_val_if_reached(NULL);
     }
 }

--- a/tests/check_el.c
+++ b/tests/check_el.c
@@ -1094,6 +1094,36 @@ START_TEST(test_ends_with)
 }
 END_TEST
 
+START_TEST(test_like)
+{
+    RTComElQuery * query = NULL;
+    RTComElIter * it = NULL;
+    gchar *contents;
+
+    query = rtcom_el_query_new(el);
+    if(!rtcom_el_query_prepare(
+        query,
+        "free-text", "AM oNLi", RTCOM_EL_OP_STR_LIKE,
+        NULL))
+    {
+        fail("Failed to prepare the query.");
+    }
+
+    it = rtcom_el_get_events(el, query);
+    g_object_unref(query);
+
+    fail_unless(it != NULL, "Failed to get iterator");
+    fail_unless(rtcom_el_iter_first(it), "Failed to start iterator");
+
+    fail_unless(rtcom_el_iter_get_values(it, "free-text", &contents, NULL));
+
+    rtcom_fail_unless_strcmp("I am online", ==, contents);
+    g_free(contents);
+
+    g_object_unref(it);
+}
+END_TEST
+
 START_TEST(test_delete_events)
 {
     RTComElQuery * query = NULL;
@@ -1660,6 +1690,7 @@ el_suite(void)
     tcase_add_test(tc_core, test_get_int);
     tcase_add_test(tc_core, test_get_string);
     tcase_add_test(tc_core, test_ends_with);
+    tcase_add_test(tc_core, test_like);
     tcase_add_test(tc_core, test_delete_events);
     tcase_add_test(tc_core, test_delete_event);
     tcase_add_test(tc_core, test_in_strv);


### PR DESCRIPTION
Adds support for a `LIKE` sql statement

```sql
SELECT * FROM Events WHERE free_text LIKE '%hi%'
```

ref: https://github.com/maemo-leste/conversations/issues/8

Needs testing